### PR TITLE
remove dasherized keys & camelCase.

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -5,8 +5,13 @@ module.exports = function(options) {
   return function(req, res, next) {
     if (options && options.create) {
       var newModel = camelcaseKeys(req.body.data.attributes);
+      var relationships = req.body.data.relationships;
 
-      _.forEach(camelcaseKeys(req.body.data.relationships), function(value, key) {
+      if (!_.isEmpty(relationships)) {
+        relationships = camelcaseKeys(req.body.data.relationships);
+      }
+
+      _.forEach(relationships, function(value, key) {
         if (value.data && value.data.id) {
           newModel[key] = value.data.id;
         }

--- a/lib/create.js
+++ b/lib/create.js
@@ -5,17 +5,17 @@ module.exports = function(options) {
   return function(req, res, next) {
     if (options && options.create) {
       var newModel = camelcaseKeys(req.body.data.attributes);
-      var relationships = req.body.data.relationships;
 
-      if (!_.isEmpty(relationships)) {
-        relationships = camelcaseKeys(req.body.data.relationships);
+      if (!_.isEmpty(req.body.data.relationships)) {
+        _.forEach(
+          camelcaseKeys(req.body.data.relationships),
+          function(value, key) {
+            if (value.data && value.data.id) {
+              newModel[key] = value.data.id;
+            }
+          }
+        );
       }
-
-      _.forEach(relationships, function(value, key) {
-        if (value.data && value.data.id) {
-          newModel[key] = value.data.id;
-        }
-      });
 
       _.assign(req, {
         // eslint-disable-next-line new-cap

--- a/lib/create.js
+++ b/lib/create.js
@@ -6,7 +6,7 @@ module.exports = function(options) {
     if (options && options.create) {
       var newModel = camelcaseKeys(req.body.data.attributes);
 
-      _.forEach(req.body.data.relationships, function(value, key) {
+      _.forEach(camelcaseKeys(req.body.data.relationships), function(value, key) {
         if (value.data && value.data.id) {
           newModel[key] = value.data.id;
         }

--- a/test/actions/create-relationships.js
+++ b/test/actions/create-relationships.js
@@ -7,6 +7,8 @@ var request = require('supertest');
 
 var fixture = require('../fixtures/loadData');
 
+var Person = require('../models/person')();
+
 describe('the create block with relationships', function() {
   beforeEach(function() {
     global.app.use(bodyParser.json());
@@ -54,6 +56,45 @@ describe('the create block with relationships', function() {
       .end(global.jsonAPIVerify(done));
   });
 
+  it.only('should camelCase relationship keys if they are dasherized', function(done) {
+    var inlawId = new mongoose.Types.ObjectId();
+    request(global.app)
+      .post('/people')
+      .type('application/json')
+      .send({
+        data: {
+          attributes: {
+            name: 'namey mc nameface',
+            age: 29,
+          },
+          relationships: {
+            'in-law': {
+              data: {
+                type: 'people',
+                id: inlawId,
+              },
+            },
+          },
+        },
+      })
+      .expect(201)
+      .expect(function(res) {
+        expect(res.body)
+          .to.have.deep.property('data.relationships.in-law.data.id', inlawId.toString());
+      })
+      .end(function(err, res) {
+        expect(err).to.not.be.ok;
+
+        Person.findOne({
+          _id: res.body.data.id,
+        })
+        .then(function(person) {
+          expect(person).to.have.property('inLaw');
+        })
+        .then(done, done);
+      });
+  });
+
   it('should not have a relationship if it is not on the request body', function(done) {
     request(global.app)
       .post('/people')
@@ -75,6 +116,7 @@ describe('the create block with relationships', function() {
       })
       .end(global.jsonAPIVerify(done));
   });
+
   it('should not add relationships that are not on the model', function(done) {
     var monkeyfaceId = new mongoose.Types.ObjectId();
     request(global.app)

--- a/test/actions/create-relationships.js
+++ b/test/actions/create-relationships.js
@@ -56,7 +56,7 @@ describe('the create block with relationships', function() {
       .end(global.jsonAPIVerify(done));
   });
 
-  it.only('should camelCase relationship keys if they are dasherized', function(done) {
+  it('should camelCase relationship keys if they are dasherized', function(done) {
     var inlawId = new mongoose.Types.ObjectId();
     request(global.app)
       .post('/people')

--- a/test/actions/create-relationships.js
+++ b/test/actions/create-relationships.js
@@ -90,8 +90,9 @@ describe('the create block with relationships', function() {
         })
         .then(function(person) {
           expect(person).to.have.property('inLaw');
+          global.jsonAPIVerify(done)(err, res);
         })
-        .then(done, done);
+        .then(null, done);
       });
   });
 

--- a/test/models/person.js
+++ b/test/models/person.js
@@ -4,7 +4,10 @@ var mongoose = require('mongoose');
 var schema = mongoose.Schema({
   name: String,
   age: Number,
-
+  inLaw: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Person',
+  },
   spouse: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Person',


### PR DESCRIPTION
Proposal to dasherize relationship keys on json api payload to fall in line with naming schemes on mongo.

e.g. cart-items -> cartItems