### PR TITLE
Deprecate Q by Bluebird

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,8 @@
       "imports": "always",
       "exports": "always",
       "functions": "never"
-    }]
+    }],
+    "no-restricted-modules": [1, "q"]
   },
   "overrides": [{
     "files": ["test/**/*.js"],

--- a/lib/deleteOne.js
+++ b/lib/deleteOne.js
@@ -1,52 +1,44 @@
-var mergeQueries = require('./helpers/mergeQueries');
-var Q = require('q');
+const mergeQueries = require('./helpers/mergeQueries');
+const Promise = require('bluebird');
 
-module.exports = function(options) {
-  return function(req, res, next) {
-    Q.fcall(function() {
-      if (options.translateId) {
-        return options.translateId(req.params.id, req);
+module.exports = options =>
+  (req, res, next) => Promise.resolve(options.translateId
+    ? options.translateId(req.params.id, req)
+    : req.params.id)
+    .then((id) => {
+      let query = {
+        _id: id,
+      };
+
+      if (req.autorouteQuery) {
+        query = mergeQueries(req.autorouteQuery, query);
       }
 
-      return req.params.id;
+      return options.model.findOneAndRemove(query).then(function(object) {
+        if (!object) {
+          throw new Error('NotFound');
+        }
+      });
     })
 
-      .then(function(id) {
-        var query = {
-          _id: id,
-        };
+    .then(function() {
+      return res.status(204).send('');
+    })
 
-        if (req.autorouteQuery) {
-          query = mergeQueries(req.autorouteQuery, query);
-        }
-
-        return options.model.findOneAndRemove(query).then(function(object) {
-          if (!object) {
-            throw new Error('NotFound');
-          }
+    .catch(function(err) {
+      if (err.name === 'CastError' || err.message === 'NotFound') {
+        res.status(404).send({
+          errors: [{
+            detail: 'Not Found',
+          }],
         });
-      })
+      } else {
+        res.status(500).send({
+          errors: [{
+            detail: err.message,
+          }],
+        });
+      }
 
-      .then(function() {
-        res.status(204).send('');
-        next();
-      })
-
-      .then(null, function(err) {
-        if (err.name === 'CastError' || err.message === 'NotFound') {
-          res.status(404).send({
-            errors: [{
-              detail: 'Not Found',
-            }],
-          });
-        } else {
-          res.status(500).send({
-            errors: [{
-              detail: err.message,
-            }],
-          });
-        }
-        return next(err);
-      });
-  };
-};
+      return next(err);
+    });

--- a/lib/findMany.js
+++ b/lib/findMany.js
@@ -1,7 +1,6 @@
-var Q = require('q');
-var _ = require('lodash');
+const _ = require('lodash');
 
-var defaultSerialise = require('./serialise');
+const defaultSerialise = require('./serialise');
 
 module.exports = function(options) {
   var isLean = options.find.lean ? options.find.lean : false;
@@ -18,9 +17,9 @@ module.exports = function(options) {
           // eslint-disable-next-line no-console
           console.warn(`You are using deprecated version of process.
 it now has 2 parameters (results, req)`);
-          return Q(options.find.process(results, null, req));
+          return options.find.process(results, null, req);
         }
-        return Q(options.find.process(results, req));
+        return options.find.process(results, req);
       }
       return results;
     }).then(function(results) {
@@ -28,6 +27,7 @@ it now has 2 parameters (results, req)`);
 
       res.json(serialiseFunction(results, options, defaultSerialise));
     }).then(null, (err) => {
+      // eslint-disable-next-line no-console
       console.log(err);
       res.status(500).send(err.message);
     });

--- a/lib/findOne.js
+++ b/lib/findOne.js
@@ -1,65 +1,48 @@
-const Q = require('q');
+const Promise = require('bluebird');
 const _ = require('lodash');
 
 var defaultSerialise = require('./serialise');
 
-module.exports = function(options) {
-  return function(req, res, next) {
-    Q.fcall(function() {
-      if (options.translateId) {
-        return options.translateId(req.params.id, req);
+module.exports = options =>
+  (req, res, next) => Promise.resolve(options.translateId
+    ? options.translateId(req.params.id, req)
+    : req.params.id)
+    .then((id) => {
+      const queryObject = req.autorouteQuery || {};
+
+      if (options.idParameter || options.find.idParameter) {
+        queryObject[options.idParameter || options.find.idParameter] = id;
+      } else {
+        queryObject._id = new options.model.base.Types.ObjectId(id);
       }
 
-      return req.params.id;
+      const query = options.model.findOne(queryObject);
+
+      if (options.find.populate) {
+        query.populate(options.find.populate);
+      }
+
+      return query.exec();
     })
+    .then(function(result) {
+      if (!result) return res.status(404).send();
 
-      .then(function(id) {
-        var queryObject = req.autorouteQuery || {};
+      return Promise.resolve(options.translateId
+        ? _.assign(result.toJSON(), { id: req.params.id, originalId: result.id })
+        : result)
+        .then(function(translatedIdResult) {
+          return options.find.processOne
+            ? options.find.processOne(translatedIdResult, req)
+            : translatedIdResult;
+        })
+        .then(function(processedResult) {
+          const serialiseFunction = _.get(options, 'find.serialise', defaultSerialise);
 
-        if (options.idParameter || options.find.idParameter) {
-          queryObject[options.idParameter || options.find.idParameter] = id;
-        } else {
-          queryObject._id = new options.model.base.Types.ObjectId(id);
-        }
-
-        var query = options.model.findOne(queryObject);
-
-        if (options.find.populate) {
-          query.populate(options.find.populate);
-        }
-
-        return query.exec();
-      })
-
-      .then(function(result) {
-        if (!result) {
-          return res.status(404).send();
-        }
-
-        return Q.fcall(function() {
-          if (options.translateId) {
-            // reverse translate id
-            return _.assign(result.toJSON(), { id: req.params.id, originalId: result.id });
-          }
-
-          return result;
-        }).then((translatedIdResult) => {
-          if (options.find.processOne) {
-            return Q(options.find.processOne(translatedIdResult, req));
-          }
-
-          return translatedIdResult;
-        }).then(function(processedResult) {
-          var serialiseFunction = _.get(options, 'find.serialise', defaultSerialise);
-
-          res.json(serialiseFunction(processedResult, options, defaultSerialise));
+          return res.json(serialiseFunction(processedResult, options, defaultSerialise));
         });
-      })
-
-      .then(null, function(err) {
-        // eslint-disable-next-line no-console
-        console.log(err);
-        return next(err);
-      });
-  };
-};
+    })
+    .catch(function(err) {
+      // eslint-disable-next-line no-console
+      console.log(err);
+      return next(err);
+    });

--- a/lib/updateOne.js
+++ b/lib/updateOne.js
@@ -1,28 +1,23 @@
-var _ = require('lodash');
-var camelcaseKeys = require('camelcase-keys');
-var Q = require('q');
+const _ = require('lodash');
+const camelcaseKeys = require('camelcase-keys');
+const Promise = require('bluebird');
 
-var defaultSerialise = require('./serialise');
-var mergeQueries = require('./helpers/mergeQueries');
+const defaultSerialise = require('./serialise');
+const mergeQueries = require('./helpers/mergeQueries');
 
-module.exports = function(options) {
-  return function(req, res, next) {
-    Q.fcall(function() {
-      if (options.translateId) {
-        return options.translateId(req.params.id, req);
-      }
-
-      return req.params.id;
-    }).then(function(id) {
-      var query = {};
+module.exports = options =>
+  (req, res, next) => Promise.resolve(options.translateId
+    ? options.translateId(req.params.id, req)
+    : req.params.id)
+    .then((id) => {
+      const newModel = {};
+      let query = {};
 
       query[options.idParameter || options.update.idParameter || '_id'] = id;
 
       if (req.autorouteQuery) {
         query = mergeQueries(req.autorouteQuery, query);
       }
-
-      var newModel = {};
 
       if (req.body.data.attributes) {
         _.assign(newModel, camelcaseKeys(req.body.data.attributes));
@@ -49,48 +44,33 @@ module.exports = function(options) {
         $set: newModel,
       }, {
         new: true,
-      }).then(function(updated) {
-        if (!updated) {
-          throw new Error('NotFound');
-        }
+      }).then((updated) => {
+        if (!updated) throw new Error('NotFound');
 
         req.model = updated;
 
-        return Q.fcall(function() {
-          if (options.translateId) {
-            // reverse translate id
-            return _.assign(updated.toJSON(), { id: req.params.id, originalId: updated.id });
-          }
-
-          return updated;
-        });
+        return Promise.resolve(options.translateId
+          ? _.assign(updated.toJSON(), { id: req.params.id, originalId: updated.id })
+          : updated);
       });
-    }).then(function(result) {
-      return Q.fcall(function() {
-        if (options.find.processOne) {
-          return Q(options.find.processOne(result, req));
-        }
-
-        return result;
-      }).then(function(processedResult) {
-        var serialiseFunction = _.get(options, 'find.serialise', defaultSerialise);
-
-        res.json(serialiseFunction(processedResult, options, defaultSerialise));
-      });
-    }).then(function() {
-      next();
     })
-      .then(null, function(err) {
-        if ((err.name === 'CastError' && err.kind === 'ObjectId') || err.message === 'NotFound') {
-          // could not cast the ID
-          res.status(404).send({
-            errors: [{
-              detail: 'Not Found',
-            }],
-          });
-        } else {
-          next(err);
-        }
-      });
-  };
-};
+    .then(function(result) {
+      return options.find.processOne
+        ? options.find.processOne(result, req)
+        : result;
+    })
+    .then((processedResult) => {
+      const serialiseFunction = _.get(options, 'find.serialise', defaultSerialise);
+      return res.json(serialiseFunction(processedResult, options, defaultSerialise));
+    })
+    .catch(function(err) {
+      if ((err.name === 'CastError' && err.kind === 'ObjectId') || err.message === 'NotFound') {
+        // could not cast the ID
+        return res.status(404).send({
+          errors: [{
+            detail: 'Not Found',
+          }],
+        });
+      }
+      return next(err);
+    });

--- a/package-lock.json
+++ b/package-lock.json
@@ -320,10 +320,16 @@
       "dev": true
     },
     "bluebird": {
+<<<<<<< Updated upstream
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
       "dev": true
+=======
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+>>>>>>> Stashed changes
     },
     "body-parser": {
       "version": "1.18.2",
@@ -1945,10 +1951,32 @@
         "sliced": "0.0.5"
       },
       "dependencies": {
+<<<<<<< Updated upstream
         "sliced": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
           "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8=",
+=======
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+>>>>>>> Stashed changes
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "winston": "^2.2.0"
   },
   "dependencies": {
+    "bluebird": "^3.5.3",
     "camelcase-keys": "^4.2.0",
     "jsonapi-serializer": "^3.3.0",
     "lodash": "^4.14.2",


### PR DESCRIPTION
* `Bluebird` is 100 times faster and uses 5% of the memory that `q` uses.
* Removed extraneous promise wrappers
* Arrow functions have no context (AKA faster)

There are some puzzling promise wrappers in the original code. I removed them. I am 91% sure they are unnecessary. But perhaps there is some odd case as to why they are there. At least the tests run fine.

Readability can be improved but I don't want to change anyone's linter settings.