### PR TITLE
Ignore me testing only

### DIFF
--- a/test/actions/create-relationships.js
+++ b/test/actions/create-relationships.js
@@ -71,10 +71,10 @@ describe('the create block with relationships', function() {
           relationships: {
             pets: {
               data: [{
-                type: 'pets',
+                type: 'animals',
                 id: dogId,
               }, {
-                type: 'pets',
+                type: 'animals',
                 id: catId,
               }],
             },
@@ -86,11 +86,11 @@ describe('the create block with relationships', function() {
         expect(res.body).to.have.nested.property('data.id');
         expect(res.body).to.have.nested.property('data.attributes.name', 'namey mc nameface');
         expect(res.body.data.relationships.pets.data).to.deep.include({
-          type: 'pets',
+          type: 'animals',
           id: dogId.toString(),
         });
         expect(res.body.data.relationships.pets.data).to.deep.include({
-          type: 'pets',
+          type: 'animals',
           id: catId.toString(),
         });
       })

--- a/test/actions/update-relationships.js
+++ b/test/actions/update-relationships.js
@@ -145,10 +145,10 @@ describe('the update block with relationships', function() {
             relationships: {
               pets: {
                 data: [{
-                  type: 'pets',
+                  type: 'animals',
                   id: dogId,
                 }, {
-                  type: 'pets',
+                  type: 'animals',
                   id: catId,
                 }],
               },

--- a/test/models/person.js
+++ b/test/models/person.js
@@ -18,7 +18,7 @@ var schema = mongoose.Schema({
   },
   pets: [{
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'Pet',
+    ref: 'Animal',
   }],
 });
 


### PR DESCRIPTION
I've cherry-picked the one-to-many test fix that makes sure the `type` is _not_ the same as the relationship name, and applied it onto master. This PR can be safely ignored and removed later, but it is to show the failing test for:

https://github.com/stonecircle/express-autoroute-json/pull/33#issuecomment-444870843

> @Redsandro do you have a test for this? that fails before the fix is applied?

Basically all I did was to change the `Pet` class to `Animal` so that the type is `animals`.

This changes `pets: [{type: 'pets'}]` to `pets: [{type: 'animals'}]` to expose this bug.

This test runs correctly on the patched PR #33 