### PR TITLE
Deprecate q 2

### DIFF
--- a/lib/deleteOne.js
+++ b/lib/deleteOne.js
@@ -1,15 +1,13 @@
-var Q = require('q');
-
 var mergeQueries = require('./helpers/mergeQueries');
 
 module.exports = function(options) {
   return function(req, res, next) {
-    Q.fcall(function() {
+    return new Promise(function(resolve) {
       if (options.translateId) {
-        return options.translateId(req.params.id, req);
+        return resolve(options.translateId(req.params.id, req));
       }
 
-      return req.params.id;
+      return resolve(req.params.id);
     })
 
       .then(function(id) {

--- a/lib/findMany.js
+++ b/lib/findMany.js
@@ -1,4 +1,3 @@
-var Q = require('q');
 var _ = require('lodash');
 
 var defaultSerialise = require('./serialise');
@@ -18,9 +17,9 @@ module.exports = function(options) {
           // eslint-disable-next-line no-console
           console.warn(`You are using deprecated version of process.
 it now has 2 parameters (results, req)`);
-          return Q(options.find.process(results, null, req));
+          return Promise.resolve(options.find.process(results, null, req));
         }
-        return Q(options.find.process(results, req));
+        return Promise.resolve(options.find.process(results, req));
       }
       return results;
     }).then(function(results) {

--- a/lib/findOne.js
+++ b/lib/findOne.js
@@ -1,16 +1,15 @@
-const Q = require('q');
 const _ = require('lodash');
 
 var defaultSerialise = require('./serialise');
 
 module.exports = function(options) {
   return function(req, res, next) {
-    Q.fcall(function() {
+    return new Promise(function(resolve) {
       if (options.translateId) {
-        return options.translateId(req.params.id, req);
+        return resolve(options.translateId(req.params.id, req));
       }
 
-      return req.params.id;
+      return resolve(req.params.id);
     })
 
       .then(function(id) {
@@ -36,16 +35,16 @@ module.exports = function(options) {
           return res.status(404).send();
         }
 
-        return Q.fcall(function() {
+        return new Promise(function(resolve) {
           if (options.translateId) {
             // reverse translate id
-            return _.assign(result.toJSON(), { id: req.params.id, originalId: result.id });
+            return resolve(_.assign(result.toJSON(), { id: req.params.id, originalId: result.id }));
           }
 
-          return result;
+          return resolve(result);
         }).then((translatedIdResult) => {
           if (options.find.processOne) {
-            return Q(options.find.processOne(translatedIdResult, req));
+            return Promise.resolve(options.find.processOne(translatedIdResult, req));
           }
 
           return translatedIdResult;

--- a/lib/updateOne.js
+++ b/lib/updateOne.js
@@ -58,7 +58,9 @@ module.exports = function(options) {
         return new Promise(function(resolve) {
           if (options.translateId) {
             // reverse translate id
-            return resolve(_.assign(updated.toJSON(), { id: req.params.id, originalId: updated.id }));
+            return resolve(
+              _.assign(updated.toJSON(), { id: req.params.id, originalId: updated.id })
+            );
           }
 
           return resolve(updated);

--- a/lib/updateOne.js
+++ b/lib/updateOne.js
@@ -1,18 +1,17 @@
 var _ = require('lodash');
 var camelcaseKeys = require('camelcase-keys');
-var Q = require('q');
 
 var defaultSerialise = require('./serialise');
 var mergeQueries = require('./helpers/mergeQueries');
 
 module.exports = function(options) {
   return function(req, res, next) {
-    Q.fcall(function() {
+    return new Promise(function(resolve) {
       if (options.translateId) {
-        return options.translateId(req.params.id, req);
+        return resolve(options.translateId(req.params.id, req));
       }
 
-      return req.params.id;
+      return resolve(req.params.id);
     }).then(function(id) {
       var query = {};
 
@@ -56,22 +55,22 @@ module.exports = function(options) {
 
         req.model = updated;
 
-        return Q.fcall(function() {
+        return new Promise(function(resolve) {
           if (options.translateId) {
             // reverse translate id
-            return _.assign(updated.toJSON(), { id: req.params.id, originalId: updated.id });
+            return resolve(_.assign(updated.toJSON(), { id: req.params.id, originalId: updated.id }));
           }
 
-          return updated;
+          return resolve(updated);
         });
       });
     }).then(function(result) {
-      return Q.fcall(function() {
+      return new Promise(function(resolve) {
         if (options.find.processOne) {
-          return Q(options.find.processOne(result, req));
+          return resolve(options.find.processOne(result, req));
         }
 
-        return result;
+        return resolve(result);
       }).then(function(processedResult) {
         var serialiseFunction = _.get(options, 'find.serialise', defaultSerialise);
 
@@ -80,7 +79,7 @@ module.exports = function(options) {
     }).then(function() {
       next();
     })
-      .then(null, function(err) {
+      .catch(function(err) {
         if ((err.name === 'CastError' && err.kind === 'ObjectId') || err.message === 'NotFound') {
           // could not cast the ID
           res.status(404).send({

--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "mongoose": "^5.3.14",
     "nyc": "^13.1.0",
     "supertest": "^3.3.0",
-    "winston": "^3.1.0"
+    "winston": "^3.1.0",
+    "q": "^1.0.1"
   },
   "dependencies": {
     "camelcase-keys": "^5.0.0",
     "jsonapi-serializer": "^3.6.4",
     "lodash": "^4.17.11",
-    "pluralize": "^7.0.0",
-    "q": "^1.0.1"
+    "pluralize": "^7.0.0"
   }
 }


### PR DESCRIPTION
There is room for removing unnecessary promises, and the linter configuration could do with some readability-improving settings, but I think this is the most basic deprecation of Q. Didn't even need to do wrapper code because only `fcall` was used. No `nfcall`.