### PR TITLE
Allow IDE to set coding style for this project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+[*.{diff,md}]
+trim_trailing_whitespace = false
+insert_final_newline = false


### PR DESCRIPTION
Switching the IDE between 2 and 4 spaces is not necessary when configuring the IDE to do this automatically.