### PR TITLE
Support include query for findOne

### DIFF
--- a/lib/findMany.js
+++ b/lib/findMany.js
@@ -9,10 +9,7 @@ module.exports = function(options) {
     var relInclude = parseInclude(req, options);
     var query = relInclude.reduce(
       (findOne, rel) => findOne.populate(rel), options.model.find(req.autorouteQuery)
-    )
-      .sort(req.autorouteSort)
-      .select(req.autorouteSelect)
-      .lean(isLean);
+    ).sort(req.autorouteSort).select(req.autorouteSelect).lean(isLean);
 
     return query.exec().then(function(results) {
       if (options.find.process) {

--- a/lib/findMany.js
+++ b/lib/findMany.js
@@ -1,17 +1,20 @@
 var _ = require('lodash');
 
 var defaultSerialise = require('./serialise');
+var parseInclude = require('./parseInclude');
 
 module.exports = function(options) {
-  var isLean = options.find.lean ? options.find.lean : false;
-
   return function(req, res) {
-    var query = options.model.find(req.autorouteQuery)
+    var isLean = options.find.lean ? options.find.lean : false;
+    var relInclude = parseInclude(req, options);
+    var query = relInclude.reduce(
+      (findOne, rel) => findOne.populate(rel), options.model.find(req.autorouteQuery)
+    )
       .sort(req.autorouteSort)
       .select(req.autorouteSelect)
       .lean(isLean);
 
-    query.exec().then(function(results) {
+    return query.exec().then(function(results) {
       if (options.find.process) {
         if (options.find.process.length === 3) {
           // eslint-disable-next-line no-console

--- a/lib/findOne.js
+++ b/lib/findOne.js
@@ -19,7 +19,7 @@ module.exports = function(options) {
       (findOne, rel) => findOne.populate(rel), options.model.findOne(queryObject)
     );
 
-    return Promise.resolve(query.exec())
+    return query.exec()
       .then(function(result) {
         if (!result) {
           return res.status(404).send();

--- a/lib/findOne.js
+++ b/lib/findOne.js
@@ -1,35 +1,25 @@
 const _ = require('lodash');
 
 var defaultSerialise = require('./serialise');
+var parseInclude = require('./parseInclude');
 
 module.exports = function(options) {
   return function(req, res, next) {
-    return new Promise(function(resolve) {
-      if (options.translateId) {
-        return resolve(options.translateId(req.params.id, req));
-      }
+    var id = options.translateId ? options.translateId(req.params.id, req) : req.params.id;
+    var relInclude = parseInclude(req, options);
+    var queryObject = req.autorouteQuery || {};
 
-      return resolve(req.params.id);
-    })
+    if (options.idParameter || options.find.idParameter) {
+      queryObject[options.idParameter || options.find.idParameter] = id;
+    } else {
+      queryObject._id = new options.model.base.Types.ObjectId(id);
+    }
 
-      .then(function(id) {
-        var queryObject = req.autorouteQuery || {};
+    var query = relInclude.reduce(
+      (findOne, rel) => findOne.populate(rel), options.model.findOne(queryObject)
+    );
 
-        if (options.idParameter || options.find.idParameter) {
-          queryObject[options.idParameter || options.find.idParameter] = id;
-        } else {
-          queryObject._id = new options.model.base.Types.ObjectId(id);
-        }
-
-        var query = options.model.findOne(queryObject);
-
-        if (options.find.populate) {
-          query.populate(options.find.populate);
-        }
-
-        return query.exec();
-      })
-
+    return Promise.resolve(query.exec())
       .then(function(result) {
         if (!result) {
           return res.status(404).send();

--- a/lib/parseInclude.js
+++ b/lib/parseInclude.js
@@ -8,20 +8,45 @@ const _ = require('lodash');
  * the leaf nodes. For example, a response to a request for `comments.author`
  * should include `comments` as well as the `author` of each of those comments."
  *
+ * @example
+ * ```javascript
+ * // Return all requested relationships:
+ * module.exports.autoroute = autorouteJson({
+ *   model: Person,
+ *   allowInclude: true,
+ *
+ *   find: {},
+ *   // ...
+ * });
+ *
+ * // Only return relationships that are whitelisted:
+ * module.exports.autoroute = autorouteJson({
+ *   model: Person,
+ *   allowInclude: ['spouse', 'pets'],
+ *
+ *   find: {},
+ *   // ...
+ * });
+ * ```
  * @param  {Object} req     Express request object
  * @param  {Object} options Holds the Schema to the Model
  * @return {Array}          Array of legal (parent) resources
  */
 module.exports = (req, options) => {
+  const allowInclude = options.allowInclude === true;
+  const whitelist = Array.isArray(options.allowInclude) ? options.allowInclude : [];
   let include = req.query.include ? req.query.include.split(',') : [];
 
-  // Get immediate nodes from leaf nodes.
+  // Only allow nodes that are accepted by the route configuration
+  include = include.filter(relationship => allowInclude || whitelist.includes(relationship));
+
+  // Get immediate nodes from leaf nodes
   include = include.map(relationship => String(relationship).split('.')[0]);
 
   // Remove duplicates
   include = include.filter((relationship, index) => include.indexOf(relationship) === index);
 
-  // Only return direct relationships defined in the schema.
+  // Only return direct relationships defined in the schema
   return include.filter((relationship) => {
     const relOptions = _.get(options.model.schema.paths, `${relationship}.options`);
     return _.get(relOptions, 'ref') || _.get(relOptions, 'type.0.ref');

--- a/lib/parseInclude.js
+++ b/lib/parseInclude.js
@@ -1,0 +1,29 @@
+const _ = require('lodash');
+
+/**
+ * Verify requested include parameters. We only return direct relationships
+ * defined in the schema. Not made up ones.
+ *
+ * "Intermediate resources in a multi-part path must be returned along with
+ * the leaf nodes. For example, a response to a request for `comments.author`
+ * should include `comments` as well as the `author` of each of those comments."
+ *
+ * @param  {Object} req     Express request object
+ * @param  {Object} options Holds the Schema to the Model
+ * @return {Array}          Array of legal (parent) resources
+ */
+module.exports = (req, options) => {
+  let include = req.query.include ? req.query.include.split(',') : [];
+
+  // Get immediate nodes from leaf nodes.
+  include = include.map(relationship => String(relationship).split('.')[0]);
+
+  // Remove duplicates
+  include = include.filter((relationship, index) => include.indexOf(relationship) === index);
+
+  // Only return direct relationships defined in the schema.
+  return include.filter((relationship) => {
+    const relOptions = _.get(options.model.schema.paths, `${relationship}.options`);
+    return _.get(relOptions, 'ref') || _.get(relOptions, 'type.0.ref');
+  });
+};

--- a/lib/serialise.js
+++ b/lib/serialise.js
@@ -33,7 +33,8 @@ module.exports = function(data, options) {
   attributes.forEach(function(attribute) {
     var attributeOptions = _.get(options.model.schema.paths, attribute + '.options');
     if (_.get(attributeOptions, 'ref') || _.get(attributeOptions, 'type.0.ref')) {
-      var ref = Array.isArray(data[attribute]) ? data[attribute][0] : data[attribute];
+      var doc = Array.isArray(data) ? data[0] : data;
+      var ref = Array.isArray(doc[attribute]) ? doc[attribute][0] : doc[attribute];
 
       // Figure out if our reference object is an ObjectID or a resource.
       // eslint-disable-next-line no-underscore-dangle

--- a/lib/serialise.js
+++ b/lib/serialise.js
@@ -33,9 +33,22 @@ module.exports = function(data, options) {
   attributes.forEach(function(attribute) {
     var attributeOptions = _.get(options.model.schema.paths, attribute + '.options');
     if (_.get(attributeOptions, 'ref') || _.get(attributeOptions, 'type.0.ref')) {
-      schema[attribute] = {
-        ref: true,
-      };
+      var ref = Array.isArray(data[attribute]) ? data[attribute][0] : data[attribute];
+
+      // Figure out if our reference object is an ObjectID or a resource.
+      // eslint-disable-next-line no-underscore-dangle
+      if (!ref || _.get(ref, '_bsontype') === 'ObjectID') {
+        // This is an unloaded relationship.
+        schema[attribute] = {
+          ref: true,
+        };
+      } else {
+        // The relationship properties should be included
+        schema[attribute] = {
+          ref: 'id',
+          attributes: Object.keys(ref.toJSON()).filter(key => !/^_/g.test(key)),
+        };
+      }
     }
   });
 

--- a/test/actions/find-relationships.js
+++ b/test/actions/find-relationships.js
@@ -98,7 +98,7 @@ describe('the find block with relationships', function() {
     });
   });
 
-  it('should include requested relationships', function(done) {
+  it('should include requested relationships for findOne', function(done) {
     Person.find().then(function(people) {
       var personOne = people[0];
       var personTwo = people[1];
@@ -106,7 +106,9 @@ describe('the find block with relationships', function() {
       var cat = new Animal({ name: 'Platypus' });
       var dog = new Animal({ name: 'Dogbark' });
 
+      // one-to-one
       personOne.spouse = personTwo;
+      // one-to-many
       personOne.pets.push(cat, dog);
 
       Promise.all([
@@ -140,6 +142,59 @@ describe('the find block with relationships', function() {
             expect(included).to.have.lengthOf(3);
             expect(included).to.deep.include({ type: 'animals', id: dog.id, attributes: { name: 'Dogbark' } });
             expect(included).to.deep.include({ type: 'animals', id: cat.id, attributes: { name: 'Platypus' } });
+          })
+          .end(global.jsonAPIVerify(done));
+      });
+    });
+  });
+
+  it('should include requested relationships for findMany', function(done) {
+    Person.find().then(function(people) {
+      var personTwo = people[1];
+      var cat = new Animal({ name: 'Platypus' });
+      var dog = new Animal({ name: 'Dogbark' });
+      var queue = [];
+
+      people.forEach((person) => {
+        // one-to-one
+        // eslint-disable-next-line no-param-reassign
+        person.spouse = personTwo;
+        // one-to-many
+        person.pets.push(cat, dog);
+        queue.push(person.save());
+      });
+
+      Promise.all([
+        cat.save(),
+        dog.save(),
+        Promise.all(queue),
+      ]).then(function() {
+        request(global.app)
+          // .get(`/people/${personOne.id}?include=spouse,dinosaurs`)
+          .get('/people/?include=spouse,pets,dinosaurs')
+          .expect(200)
+          .expect(function(res) {
+            var { data, included } = res.body;
+
+            expect(data).to.be.a('array');
+            expect(data).to.have.nested.property('[0].id');
+            expect(data).to.have.nested.property('[0].type', 'people');
+            expect(data).to.have.nested.property('[0].attributes.age');
+            expect(data).to.have.nested.property('[0].relationships');
+            expect(data).to.have.nested.property('[0].relationships.pets.data[0].type', 'animals');
+            expect(data).to.not.have.nested.property('[0].relationships', 'dinosaurs');
+
+            // Two keys; not accidentally the whole document.
+            expect(Object.keys(data[0].relationships.spouse.data)).to.have.lengthOf(2);
+            expect(Object.keys(data[0].relationships.pets.data[0])).to.have.lengthOf(2);
+
+            // Data should be included
+            expect(included).to.be.a('array');
+            expect(included).to.have.lengthOf(3);
+            // eslint-disable-next-line object-curly-newline
+            expect(included).to.deep.include({ type: 'animals', id: dog.id, attributes: { name: 'Dogbark' }, relationships: {} });
+            // eslint-disable-next-line object-curly-newline
+            expect(included).to.deep.include({ type: 'animals', id: cat.id, attributes: { name: 'Platypus' }, relationships: {} });
           })
           .end(global.jsonAPIVerify(done));
       });

--- a/test/actions/find-relationships.js
+++ b/test/actions/find-relationships.js
@@ -8,6 +8,8 @@ var fixture = require('../fixtures/find-relationships/loadData');
 
 var Person = require('../models/person')();
 
+var Animal = require('../models/animal')();
+
 describe('the find block with relationships', function() {
   beforeEach(function() {
     autoroute(global.app, {
@@ -90,6 +92,54 @@ describe('the find block with relationships', function() {
               .to.have.nested.property('pets');
             expect(res.body.data.relationships)
               .to.have.nested.property('pets.data[0].id', pets[0].toString());
+          })
+          .end(global.jsonAPIVerify(done));
+      });
+    });
+  });
+
+  it('should include requested relationships', function(done) {
+    Person.find().then(function(people) {
+      var personOne = people[0];
+      var personTwo = people[1];
+
+      var cat = new Animal({ name: 'Platypus' });
+      var dog = new Animal({ name: 'Dogbark' });
+
+      personOne.spouse = personTwo;
+      personOne.pets.push(cat, dog);
+
+      Promise.all([
+        cat.save(),
+        dog.save(),
+        personOne.save(),
+      ]).then(function() {
+        request(global.app)
+          // .get(`/people/${personOne.id}?include=spouse,dinosaurs`)
+          .get(`/people/${personOne.id}?include=spouse,pets,dinosaurs`)
+          .expect(200)
+          .expect(function(res) {
+            var { data, included } = res.body;
+            expect(data).to.have.property('relationships');
+            expect(data.relationships).to.not.have.property('dinosaurs');
+
+            // Spouse one-to-one. Two keys; not accidentally the whole document.
+            expect(data.relationships).to.have.nested.property('spouse.data.id', personTwo.id);
+            expect(data.relationships).to.have.nested.property('spouse.data.type', 'people');
+            expect(Object.keys(data.relationships.spouse.data)).to.have.lengthOf(2);
+
+            // Pets. Same treatment, but for one-to-many
+            expect(data.relationships).to.have.nested.property('pets.data');
+            expect(data.relationships.pets.data).to.be.a('array');
+            expect(data.relationships.pets.data).to.have.lengthOf(2);
+            expect(data.relationships).to.have.nested.property('pets.data[0].id', cat.id);
+            expect(data.relationships).to.have.nested.property('pets.data[0].type', 'animals');
+
+            // Data should be included
+            expect(included).to.be.a('array');
+            expect(included).to.have.lengthOf(3);
+            expect(included).to.deep.include({ type: 'animals', id: dog.id, attributes: { name: 'Dogbark' } });
+            expect(included).to.deep.include({ type: 'animals', id: cat.id, attributes: { name: 'Platypus' } });
           })
           .end(global.jsonAPIVerify(done));
       });

--- a/test/fixtures/find-relationships/simple.js
+++ b/test/fixtures/find-relationships/simple.js
@@ -4,4 +4,5 @@ var Person = require('../../models/person')();
 module.exports.autoroute = autorouteJson({
   model: Person,
   find: {},
+  allowInclude: ['spouse', 'pets'],
 });

--- a/test/models/animal.js
+++ b/test/models/animal.js
@@ -1,0 +1,17 @@
+var mongoose = require('mongoose');
+
+// eslint-disable-next-line new-cap
+var schema = mongoose.Schema({
+  name: String,
+});
+
+// eslint-disable-next-line consistent-return
+module.exports = function() {
+  try {
+    if (mongoose.model('Animal')) {
+      return mongoose.model('Animal');
+    }
+  } catch (err) {
+    return mongoose.model('Animal', schema);
+  }
+};


### PR DESCRIPTION
:warning: __This is a work-in-progress.__

Do not merge. I will keep updating this branch from time to time.

@mansona it's really quite cumbersome and a _lot_ of work if we were to use the exact route pipeline for a relationship. :thinking: 

Keeping things internal is surprisingly efficient, because we can cut corners by outsourcing functionality to `mongoose` and `jsonapi-serializer` (as we should imo). :robot: 

I propose that I get auth working on this so it is safe. As for the rest of possible pipeline functions, I don't think it's worth it investing serious serious serious time to write an implementation for this, because no one is depending on it (yet or ever). I will write the important and safe basic, and someone else can, if it is worth their while, implement the crazy.

Keep in mind that nothing changes for people _not_ using `include`.

---
# TO DO

### Must have

- [x] `?include` support for `findOne()` (single)
- [x] `?include` support for `findMany()` (single)
- [x] permissions

### Should have

- [ ] `?include` support for `findOne()` (multi)
- [ ] `?include` support for `findMany()` (multi)