### PR TITLE
Allow select for findOne too

### DIFF
--- a/lib/findOne.js
+++ b/lib/findOne.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
           queryObject._id = new options.model.base.Types.ObjectId(id);
         }
 
-        var query = options.model.findOne(queryObject);
+        var query = options.model.findOne(queryObject).select(req.autorouteSelect);
 
         if (options.find.populate) {
           query.populate(options.find.populate);

--- a/lib/generateAutoroute.js
+++ b/lib/generateAutoroute.js
@@ -62,6 +62,7 @@ module.exports = function(options) {
 
       options.preMiddleware || identityMiddleware,
       _.get(options, 'find.preMiddleware', identityMiddleware),
+      selectFunction(options),
       findOne(options),
       error,
     ];


### PR DESCRIPTION
It's convenient to use the `select` option for fetching [sparse fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets).

```javascript
module.exports.autoroute = autorouteJson({
    model,
    resource,
    find: {
        select(req) {
            // some sensible code here
            return ['-skip', '-these', '-fields']
        }
    }
}
```

However, they should work on both `findOne()` and `findMany()`. Currently, it only works on `findMany()`.
 This small fix implements what was probably intended.